### PR TITLE
Revert "Use INIT_D_DIR instead of init.d"

### DIFF
--- a/recipes-bsp/extra/vuplus-coldboot.bb
+++ b/recipes-bsp/extra/vuplus-coldboot.bb
@@ -10,12 +10,12 @@ SRC_REV = ""
 SRC_URI = "http://code.vuplus.com/download/release/openpli-support/vuplus-coldboot_${SRCDATE}.tar.gz"
 
 do_install() {
-	install -d ${D}${INIT_D_DIR} \
+	install -d ${D}${sysconfdir}/init.d \
 		${D}${bindir} \
         	${D}${sysconfdir}/rc0.d 
 
-	install -m 0755 ${WORKDIR}/${PN}/coldboot.sh ${D}${INIT_D_DIR}/coldboot.sh
-	install -m 0755 ${WORKDIR}/${PN}/ethwol.sh ${D}${INIT_D_DIR}/ethwol.sh
+	install -m 0755 ${WORKDIR}/${PN}/coldboot.sh ${D}${sysconfdir}/init.d/coldboot.sh
+	install -m 0755 ${WORKDIR}/${PN}/ethwol.sh ${D}${sysconfdir}/init.d/ethwol.sh
 	install -m 0755 ${WORKDIR}/${PN}/coldboot ${D}${bindir}/coldboot
         ln -sf   ../init.d/coldboot.sh ${D}${sysconfdir}/rc0.d/S30coldboot.sh
 	ln -sf   ../init.d/ethwol.sh ${D}${sysconfdir}/rc0.d/K32ethwol.sh

--- a/recipes-bsp/extra/vuplus-hdmi-in-helper.bb
+++ b/recipes-bsp/extra/vuplus-hdmi-in-helper.bb
@@ -13,10 +13,10 @@ SRC_URI = "\
 S = "${WORKDIR}"
 
 do_install() {
-	install -d ${D}${INIT_D_DIR}/
+	install -d ${D}${sysconfdir}/init.d/
 	install -d ${D}${bindir}
 	install -m 0755 ${WORKDIR}/update_systemconfig_arm ${D}${bindir}/update_systemconfig
-	install -m 0755 ${WORKDIR}/update_systemconfig.sh ${D}${INIT_D_DIR}/
+	install -m 0755 ${WORKDIR}/update_systemconfig.sh ${D}${sysconfdir}/init.d/
 }
 
 inherit update-rc.d

--- a/recipes-bsp/extra/vuplus-shutdown.bb
+++ b/recipes-bsp/extra/vuplus-shutdown.bb
@@ -9,9 +9,9 @@ SRC_URI = " \
 DEPENDS_append = " update-rc.d-native"
 
 do_install() {
-        install -d ${D}${INIT_D_DIR}/
+        install -d ${D}${sysconfdir}/init.d/
 	install -d ${D}${sysconfdir}/rc0.d
-        install -m 0755 ${WORKDIR}/vuplus-shutdown.sh ${D}${INIT_D_DIR}/vuplus-shutdown
+        install -m 0755 ${WORKDIR}/vuplus-shutdown.sh ${D}${sysconfdir}/init.d/vuplus-shutdown
         install -d ${D}${bindir}
         install -m 0755 ${WORKDIR}/turnoff_power ${D}${bindir}
         update-rc.d -r ${D} vuplus-shutdown start 89 0 .


### PR DESCRIPTION
This reverts commit 771f8cdb8b227f6b2c877a390e133615f52572e9.

same as https://github.com/OpenVisionE2/openvision-development-platform/commit/db1384d14e9a95758815923ee48f7568f8ecbe68 commit 